### PR TITLE
Enable bypass shutdown function and force enable

### DIFF
--- a/lib/benchmark.php
+++ b/lib/benchmark.php
@@ -25,20 +25,24 @@ class Benchmark extends \Prefab {
   /**
    * Benchmark constructor
    *
+   * @param bool $registerShutdown
+   * @param bool $force
    * @return void
    */
-  function __construct() {
+  function __construct($registerShutdown=true,$force=false) {
     $this->isBenchmarkEnable = false;
 
     $f3 = \Base::instance();
-    if ($f3->get('DEBUG') >= 3) {
+    if ($f3->get('DEBUG') >= 3 || $force==true) {
       $this->isBenchmarkEnable = true;
       $this->init();
 
-      register_shutdown_function(function () {
-        $this->enhanceExecutionTime();
-        print $this->getFormattedBenchmark();
-      });
+      if ($registerShutdown) {
+          register_shutdown_function(function () {
+              $this->enhanceExecutionTime();
+              print $this->getFormattedBenchmark();
+          });
+      }
     }
 
     // you can comment below line if you don't need to call checkPoint()


### PR DESCRIPTION
Adding 2 variable into construct to enable bypass register_shutdown_function and to force enable benchmark.

This changes should not affect existing, but will enable to manually add display on template.
Example:
index.php
$f3->set('benchmark',new \Benchmark(false,true));

page.php
function afterroute() {
        $this->f3->get('benchmark')->enhanceExecutionTime();
        $this->f3->set('benchmarkDisplay',$this->f3->get('benchmark')->getFormattedBenchmark());
        echo \Template::instance()->render('layout.htm');
    }

layout.htm
{{ @benchmarkDisplay | raw }}
</body>
</html>